### PR TITLE
BOS-795: deploy BOS-121 canonical calculator rollout via protected workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
 
     - run: npm ci
     - run: npm run build
+    - run: bash ./scripts/apply-bos-121-canonical-payload.sh
 
     - name: Install SSH keys
       run: |
@@ -87,7 +88,8 @@ jobs:
           exit 0
         fi
 
-        rsync -avz --delete \
+        # Keep the mirror additive until repo/live utility inventory is reconciled.
+        rsync -avz \
           --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r \
           dist/ "stackcp:~/public_html/bosonit.org/"
 
@@ -99,27 +101,108 @@ jobs:
           exit 1
         fi
 
+        declare -A CANONICAL_ALIAS_BY_SLUG=(
+          [mortgage-payment-calculator]=mortgage-calculator
+          [calorie-deficit-calculator]=calorie-calculator
+          [sales-tax-calculator]=sales-tax-calculator
+        )
+
         ssh vps0 'grep -q "Revenue Leak Audit" /var/www/bosonit/services/index.html'
         ssh vps0 'grep -q "\"schema_version\"" /var/www/bosonit/observatory/control-plane.latest.json'
+        ssh vps0 'test -f /var/www/bosonit/.htaccess'
+        ssh vps0 'test -f /var/www/bosonit/utility-sites/index.html'
+        ssh vps0 'test -f /var/www/bosonit/observatory/utility-sites.latest.json'
+        ssh vps0 'test -f /var/www/bosonit/sitemap.xml'
+        ssh vps0 'grep -q "href=\"/mortgage-calculator/\"" /var/www/bosonit/utility-sites/index.html'
+        ssh vps0 'grep -q "href=\"/calorie-calculator/\"" /var/www/bosonit/utility-sites/index.html'
+        ssh vps0 'grep -q "href=\"/sales-tax-calculator/\"" /var/www/bosonit/utility-sites/index.html'
+        ssh vps0 'grep -q "\"preview_url\": \"/mortgage-calculator/\"" /var/www/bosonit/observatory/utility-sites.latest.json'
+        ssh vps0 'grep -q "\"preview_url\": \"/calorie-calculator/\"" /var/www/bosonit/observatory/utility-sites.latest.json'
+        ssh vps0 'grep -q "\"preview_url\": \"/sales-tax-calculator/\"" /var/www/bosonit/observatory/utility-sites.latest.json'
+        ssh vps0 'grep -q "https://www.bosonit.org/utility-sites/" /var/www/bosonit/sitemap.xml'
+        ssh vps0 'grep -q "https://www.bosonit.org/mortgage-calculator/" /var/www/bosonit/sitemap.xml'
+        ssh vps0 'grep -q "https://www.bosonit.org/calorie-calculator/" /var/www/bosonit/sitemap.xml'
+        ssh vps0 'grep -q "https://www.bosonit.org/sales-tax-calculator/" /var/www/bosonit/sitemap.xml'
+
+        for slug in mortgage-payment-calculator calorie-deficit-calculator sales-tax-calculator; do
+          alias="${CANONICAL_ALIAS_BY_SLUG[$slug]}"
+          ssh vps0 "test -f /var/www/bosonit/${alias}/index.html"
+          ssh vps0 "test -f /var/www/bosonit/${alias}/tool.js"
+          ssh vps0 "test -f /var/www/bosonit/${alias}/styles.css"
+          ssh vps0 "test -f /var/www/bosonit/${alias}/faq-schema.json"
+          ssh vps0 "grep -q \"rel=\\\"canonical\\\" href=\\\"https://www.bosonit.org/${alias}/\\\"\" /var/www/bosonit/${alias}/index.html"
+          ssh vps0 "test -f /var/www/bosonit/utility-sites/${slug}/index.html"
+          ssh vps0 "test -f /var/www/bosonit/utility-sites/${slug}/tool.js"
+          ssh vps0 "test -f /var/www/bosonit/utility-sites/${slug}/styles.css"
+          ssh vps0 "test -f /var/www/bosonit/utility-sites/${slug}/faq-schema.json"
+          ssh vps0 "grep -q \"RewriteRule \\^utility-sites/${slug}/?\\$ /${alias}/ \\[R=301,L\\]\" /var/www/bosonit/.htaccess"
+          ssh vps0 "grep -q \"RewriteRule \\^utility-sites/${slug}/index\\\\.html\\$ /${alias}/ \\[R=301,L\\]\" /var/www/bosonit/.htaccess"
+        done
         echo "Origin verification passed on vps0."
 
         nonce="$(date +%s)-$RANDOM"
         services_status="$(curl -sS -o /tmp/services-response.html -w '%{http_code}' "https://www.bosonit.org/services/?cb=${nonce}" || true)"
         observatory_status="$(curl -sS -o /tmp/observatory-response.json -w '%{http_code}' "https://www.bosonit.org/observatory/control-plane.latest.json?cb=${nonce}" || true)"
+        utility_observatory_status="$(curl -sS -o /tmp/utility-sites-response.json -w '%{http_code}' "https://www.bosonit.org/observatory/utility-sites.latest.json?cb=${nonce}" || true)"
+        utility_hub_status="$(curl -sS -o /tmp/utility-sites-hub-response.html -w '%{http_code}' "https://www.bosonit.org/utility-sites/?cb=${nonce}" || true)"
+        sitemap_status="$(curl -sS -o /tmp/sitemap.xml -w '%{http_code}' "https://www.bosonit.org/sitemap.xml?cb=${nonce}" || true)"
         services_status="${services_status:-000}"
         observatory_status="${observatory_status:-000}"
+        utility_observatory_status="${utility_observatory_status:-000}"
+        utility_hub_status="${utility_hub_status:-000}"
+        sitemap_status="${sitemap_status:-000}"
 
-        if [ "$services_status" = "200" ] && [ "$observatory_status" = "200" ]; then
+        canonical_statuses=""
+        legacy_statuses=""
+        : > /tmp/canonical-route-statuses.txt
+        : > /tmp/legacy-route-statuses.txt
+        : > /tmp/legacy-route-locations.txt
+        for slug in mortgage-payment-calculator calorie-deficit-calculator sales-tax-calculator; do
+          alias="${CANONICAL_ALIAS_BY_SLUG[$slug]}"
+          canonical_status="$(curl -sS -o "/tmp/${alias}-response.html" -w '%{http_code}' "https://www.bosonit.org/${alias}/?cb=${nonce}" || true)"
+          legacy_status="$(curl -sS -D "/tmp/${slug}-headers.txt" -o "/tmp/${slug}-response.html" -w '%{http_code}' "https://www.bosonit.org/utility-sites/${slug}/?cb=${nonce}" || true)"
+          canonical_status="${canonical_status:-000}"
+          legacy_status="${legacy_status:-000}"
+          canonical_statuses="${canonical_statuses} ${alias}=${canonical_status}"
+          legacy_statuses="${legacy_statuses} ${slug}=${legacy_status}"
+          printf '%s=%s\n' "${alias}" "${canonical_status}" >> /tmp/canonical-route-statuses.txt
+          printf '%s=%s\n' "${slug}" "${legacy_status}" >> /tmp/legacy-route-statuses.txt
+          awk 'BEGIN{IGNORECASE=1} /^location:/ {print}' "/tmp/${slug}-headers.txt" >> /tmp/legacy-route-locations.txt
+        done
+
+        if [ "$services_status" = "200" ] && [ "$observatory_status" = "200" ] && [ "$utility_observatory_status" = "200" ] && [ "$utility_hub_status" = "200" ] && [ "$sitemap_status" = "200" ] && ! grep -vq '=200$' /tmp/canonical-route-statuses.txt && ! grep -vq '=301$' /tmp/legacy-route-statuses.txt; then
           grep -q "Revenue Leak Audit" /tmp/services-response.html
-          grep -q "\"schema_version\"" /tmp/observatory-response.json
-          echo "Public edge verification passed."
+          grep -q '"schema_version"' /tmp/observatory-response.json
+          grep -q '"preview_url": "/mortgage-calculator/"' /tmp/utility-sites-response.json
+          grep -q '"preview_url": "/calorie-calculator/"' /tmp/utility-sites-response.json
+          grep -q '"preview_url": "/sales-tax-calculator/"' /tmp/utility-sites-response.json
+          grep -q 'href="/mortgage-calculator/"' /tmp/utility-sites-hub-response.html
+          grep -q 'href="/calorie-calculator/"' /tmp/utility-sites-hub-response.html
+          grep -q 'href="/sales-tax-calculator/"' /tmp/utility-sites-hub-response.html
+          grep -q 'https://www.bosonit.org/utility-sites/' /tmp/sitemap.xml
+          grep -q 'https://www.bosonit.org/mortgage-calculator/' /tmp/sitemap.xml
+          grep -q 'https://www.bosonit.org/calorie-calculator/' /tmp/sitemap.xml
+          grep -q 'https://www.bosonit.org/sales-tax-calculator/' /tmp/sitemap.xml
+          for slug in mortgage-payment-calculator calorie-deficit-calculator sales-tax-calculator; do
+            alias="${CANONICAL_ALIAS_BY_SLUG[$slug]}"
+            case "${slug}" in
+              mortgage-payment-calculator) grep -q 'Mortgage Payment Calculator' "/tmp/${alias}-response.html" ;;
+              calorie-deficit-calculator) grep -q 'Calorie Deficit Calculator' "/tmp/${alias}-response.html" ;;
+              sales-tax-calculator) grep -q 'Sales Tax Calculator' "/tmp/${alias}-response.html" ;;
+            esac
+            grep -q "rel=\"canonical\" href=\"https://www.bosonit.org/${alias}/\"" "/tmp/${alias}-response.html"
+            grep -q "${alias}=200" /tmp/canonical-route-statuses.txt
+            grep -q "${slug}=301" /tmp/legacy-route-statuses.txt
+            grep -Eiq "location: (https://www\.bosonit\.org)?/${alias}/" "/tmp/${slug}-headers.txt"
+          done
+          echo "Public edge verification passed. canonical=${canonical_statuses} legacy=${legacy_statuses}"
           exit 0
         fi
 
-        if [ "$services_status" = "403" ] || [ "$observatory_status" = "403" ]; then
+        if [ "$services_status" = "403" ] || [ "$observatory_status" = "403" ] || [ "$utility_observatory_status" = "403" ] || [ "$utility_hub_status" = "403" ] || [ "$sitemap_status" = "403" ] || grep -q '=403$' /tmp/canonical-route-statuses.txt || grep -q '=403$' /tmp/legacy-route-statuses.txt; then
           echo "Public edge verification returned 403 (likely WAF from GitHub runner); treated as non-blocking."
           exit 0
         fi
 
-        echo "Public edge verification failed with statuses services=${services_status} observatory=${observatory_status}."
+        echo "Public edge verification failed with statuses services=${services_status} observatory=${observatory_status} utility_observatory=${utility_observatory_status} utility_hub=${utility_hub_status} sitemap=${sitemap_status} canonical_routes=${canonical_statuses} legacy_routes=${legacy_statuses}."
         exit 1

--- a/scripts/apply-bos-121-canonical-payload.sh
+++ b/scripts/apply-bos-121-canonical-payload.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash ./scripts/apply-bos-121-canonical-payload.sh [options]
+
+Options:
+  --dist-root PATH   Dist root to overlay. Defaults to ./dist
+  --base-url URL     Source site to snapshot. Defaults to https://www.bosonit.org
+  -h, --help         Show help.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+dist_root="${REPO_ROOT}/dist"
+base_url="https://www.bosonit.org"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dist-root)
+      dist_root="${2:-}"
+      shift 2
+      ;;
+    --base-url)
+      base_url="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for required in curl mkdir mktemp perl rg cp; do
+  if ! command -v "${required}" >/dev/null 2>&1; then
+    echo "Missing required command: ${required}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p \
+  "${dist_root}" \
+  "${dist_root}/utility-sites" \
+  "${dist_root}/observatory"
+
+fetch_file() {
+  local url="$1"
+  local output_path="$2"
+  curl -fsSL "${url}" -o "${output_path}"
+}
+
+strip_cloudflare_injection() {
+  local html_path="$1"
+  perl -0pi -e 's#\n\s*<script>\(function\(\)\{.*?window\.__CF\$cv\$params.*?</script>\s*</body>#\n  </body>#s' "${html_path}"
+}
+
+rewrite_short_alias_html() {
+  local html_path="$1"
+  local slug="$2"
+  local alias="$3"
+
+  strip_cloudflare_injection "${html_path}"
+
+  perl -0pi -e '
+    s#https://www\.bosonit\.org/utility-sites/'"${slug}"'/#https://www.bosonit.org/'"${alias}"'/#g;
+    s#<a class="brand" href="\.\./">#<a class="brand" href="/utility-sites/">#g;
+    s#href="\.\./sales-tax-calculator/"#href="/sales-tax-calculator/"#g;
+    s#href="\.\./mortgage-payment-calculator/"#href="/mortgage-calculator/"#g;
+    s#href="\.\./calorie-deficit-calculator/"#href="/calorie-calculator/"#g;
+  ' "${html_path}"
+}
+
+write_file() {
+  local output_path="$1"
+  mkdir -p "$(dirname "${output_path}")"
+  cat > "${output_path}"
+}
+
+write_htaccess() {
+  write_file "${dist_root}/.htaccess" <<'EOF'
+RewriteEngine On
+RewriteBase /
+
+# BOS-121 canonical calculator aliases.
+RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]
+RewriteRule ^utility-sites/mortgage-payment-calculator/index\.html$ /mortgage-calculator/ [R=301,L]
+RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]
+RewriteRule ^utility-sites/calorie-deficit-calculator/index\.html$ /calorie-calculator/ [R=301,L]
+RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]
+RewriteRule ^utility-sites/sales-tax-calculator/index\.html$ /sales-tax-calculator/ [R=301,L]
+
+# Serve real files and directories first.
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+# Explicit static routes that must bypass generic homepage fallback.
+RewriteRule ^services/?$ /services/index.html [L]
+RewriteRule ^control-plane/?$ /control-plane/index.html [L]
+RewriteRule ^observatory/control-plane.latest.json$ /observatory/control-plane.latest.json [L]
+
+# Default SPA/static fallback.
+RewriteRule . /index.html [L]
+EOF
+}
+
+write_hub() {
+  write_file "${dist_root}/utility-sites/index.html" <<'EOF'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BosonIT Utility Calculators</title>
+    <link rel="icon" href="data:," />
+    <meta
+      name="description"
+      content="Browse the approved BosonIT utility calculator rollout with short canonical routes for mortgage planning, calorie-deficit estimates, and sales tax math."
+    />
+    <link rel="canonical" href="https://www.bosonit.org/utility-sites/" />
+    <meta property="og:url" content="https://www.bosonit.org/utility-sites/" />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4f6f2;
+        --panel: #ffffff;
+        --ink: #17211d;
+        --muted: #52605a;
+        --line: rgba(37, 63, 51, 0.14);
+        --accent: #126a52;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(180deg, #fbfcf8 0%, var(--bg) 100%);
+        color: var(--ink);
+        font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        width: min(960px, calc(100% - 2rem));
+        margin: 0 auto;
+        padding: 2rem 0 4rem;
+      }
+
+      .hero,
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: 0 18px 34px rgba(24, 34, 29, 0.08);
+      }
+
+      .hero {
+        padding: 1.75rem;
+      }
+
+      .eyebrow {
+        margin: 0 0 0.5rem;
+        color: var(--accent);
+        font-size: 0.85rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1,
+      h2,
+      p {
+        margin-top: 0;
+      }
+
+      .grid {
+        display: grid;
+        gap: 1rem;
+        margin-top: 1.5rem;
+      }
+
+      .card {
+        display: block;
+        padding: 1.25rem;
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .route-chip {
+        display: inline-block;
+        margin-bottom: 0.75rem;
+        padding: 0.3rem 0.65rem;
+        border-radius: 999px;
+        background: rgba(18, 106, 82, 0.1);
+        color: var(--accent);
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.85rem;
+      }
+
+      a:hover .route-chip {
+        background: rgba(18, 106, 82, 0.18);
+      }
+
+      .note {
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <p class="eyebrow">BOS-121 Canonical Rollout</p>
+        <h1>BosonIT Utility Calculators</h1>
+        <p>
+          This rollout keeps the public utility lane focused on the three approved short canonical
+          calculator routes while preserving the archive path and legacy redirects.
+        </p>
+        <p class="note">
+          Approved routes: mortgage payment, calorie deficit, and sales tax.
+        </p>
+      </section>
+
+      <section class="grid" aria-label="Approved utility calculators">
+        <a class="card" href="/mortgage-calculator/">
+          <span class="route-chip">/mortgage-calculator/</span>
+          <h2>Mortgage Payment Calculator</h2>
+          <p>Estimate principal-and-interest payment size instantly on the approved short route.</p>
+        </a>
+
+        <a class="card" href="/calorie-calculator/">
+          <span class="route-chip">/calorie-calculator/</span>
+          <h2>Calorie Deficit Calculator</h2>
+          <p>Estimate a calorie deficit target with a short shareable route and transparent assumptions.</p>
+        </a>
+
+        <a class="card" href="/sales-tax-calculator/">
+          <span class="route-chip">/sales-tax-calculator/</span>
+          <h2>Sales Tax Calculator</h2>
+          <p>Calculate subtotal, tax, and total instantly on the approved sales tax short route.</p>
+        </a>
+      </section>
+    </main>
+  </body>
+</html>
+EOF
+}
+
+write_sitemap() {
+  write_file "${dist_root}/sitemap.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.bosonit.org/</loc>
+  </url>
+  <url>
+    <loc>https://www.bosonit.org/services/</loc>
+  </url>
+  <url>
+    <loc>https://www.bosonit.org/control-plane/</loc>
+  </url>
+  <url>
+    <loc>https://www.bosonit.org/utility-sites/</loc>
+  </url>
+  <url>
+    <loc>https://www.bosonit.org/mortgage-calculator/</loc>
+  </url>
+  <url>
+    <loc>https://www.bosonit.org/calorie-calculator/</loc>
+  </url>
+  <url>
+    <loc>https://www.bosonit.org/sales-tax-calculator/</loc>
+  </url>
+</urlset>
+EOF
+}
+
+write_observatory_snapshot() {
+  write_file "${dist_root}/observatory/utility-sites.latest.json" <<'EOF'
+{
+  "all_pilots_file_complete": true,
+  "generated_at_utc": "2026-05-10T00:00:00.000000+00:00",
+  "pilot_count": 3,
+  "pilots": [
+    {
+      "cluster_key": "calorie",
+      "computation_mode": "calorie-deficit",
+      "has_css_ref": true,
+      "has_js_ref": true,
+      "missing_files": [],
+      "preview_url": "/calorie-calculator/",
+      "primary_keyword": "calorie deficit calculator",
+      "publish_target": "bosonit-site-canonical-rollout",
+      "published_files": [
+        "index.html",
+        "tool.js",
+        "styles.css",
+        "faq-schema.json"
+      ],
+      "site_slug": "calorie-deficit-calculator",
+      "status": "published"
+    },
+    {
+      "cluster_key": "mortgage",
+      "computation_mode": "mortgage-payment",
+      "has_css_ref": true,
+      "has_js_ref": true,
+      "missing_files": [],
+      "preview_url": "/mortgage-calculator/",
+      "primary_keyword": "mortgage payment calculator",
+      "publish_target": "bosonit-site-canonical-rollout",
+      "published_files": [
+        "index.html",
+        "tool.js",
+        "styles.css",
+        "faq-schema.json"
+      ],
+      "site_slug": "mortgage-payment-calculator",
+      "status": "published"
+    },
+    {
+      "cluster_key": "sales",
+      "computation_mode": "sales-tax",
+      "has_css_ref": true,
+      "has_js_ref": true,
+      "missing_files": [],
+      "preview_url": "/sales-tax-calculator/",
+      "primary_keyword": "sales tax calculator",
+      "publish_target": "bosonit-site-canonical-rollout",
+      "published_files": [
+        "index.html",
+        "tool.js",
+        "styles.css",
+        "faq-schema.json"
+      ],
+      "site_slug": "sales-tax-calculator",
+      "status": "published"
+    }
+  ],
+  "schema_version": "2026-05-10.utility-sites-canonical-rollout.v1",
+  "source": "BOS-121 canonical rollout overlay"
+}
+EOF
+}
+
+fetch_route_bundle() {
+  local slug="$1"
+  local alias="$2"
+  local legacy_dir="${dist_root}/utility-sites/${slug}"
+  local alias_dir="${dist_root}/${alias}"
+
+  mkdir -p "${legacy_dir}" "${alias_dir}"
+
+  fetch_file "${base_url}/utility-sites/${slug}/index.html" "${legacy_dir}/index.html"
+  fetch_file "${base_url}/utility-sites/${slug}/tool.js" "${legacy_dir}/tool.js"
+  fetch_file "${base_url}/utility-sites/${slug}/styles.css" "${legacy_dir}/styles.css"
+  fetch_file "${base_url}/utility-sites/${slug}/faq-schema.json" "${legacy_dir}/faq-schema.json"
+  strip_cloudflare_injection "${legacy_dir}/index.html"
+
+  cp "${legacy_dir}/tool.js" "${alias_dir}/tool.js"
+  cp "${legacy_dir}/styles.css" "${alias_dir}/styles.css"
+  cp "${legacy_dir}/faq-schema.json" "${alias_dir}/faq-schema.json"
+  cp "${legacy_dir}/index.html" "${alias_dir}/index.html"
+  rewrite_short_alias_html "${alias_dir}/index.html" "${slug}" "${alias}"
+}
+
+verify_output() {
+  rg -Fq 'href="/mortgage-calculator/"' "${dist_root}/utility-sites/index.html"
+  rg -Fq 'href="/calorie-calculator/"' "${dist_root}/utility-sites/index.html"
+  rg -Fq 'href="/sales-tax-calculator/"' "${dist_root}/utility-sites/index.html"
+  rg -Fq 'rel="canonical" href="https://www.bosonit.org/mortgage-calculator/"' "${dist_root}/mortgage-calculator/index.html"
+  rg -Fq 'rel="canonical" href="https://www.bosonit.org/calorie-calculator/"' "${dist_root}/calorie-calculator/index.html"
+  rg -Fq 'rel="canonical" href="https://www.bosonit.org/sales-tax-calculator/"' "${dist_root}/sales-tax-calculator/index.html"
+  rg -Fq 'RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]' "${dist_root}/.htaccess"
+  rg -Fq 'RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]' "${dist_root}/.htaccess"
+  rg -Fq 'RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]' "${dist_root}/.htaccess"
+  rg -Fq '"preview_url": "/mortgage-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
+  rg -Fq '"preview_url": "/calorie-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
+  rg -Fq '"preview_url": "/sales-tax-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
+  rg -Fq 'https://www.bosonit.org/utility-sites/' "${dist_root}/sitemap.xml"
+  rg -Fq 'https://www.bosonit.org/mortgage-calculator/' "${dist_root}/sitemap.xml"
+  rg -Fq 'https://www.bosonit.org/calorie-calculator/' "${dist_root}/sitemap.xml"
+  rg -Fq 'https://www.bosonit.org/sales-tax-calculator/' "${dist_root}/sitemap.xml"
+}
+
+fetch_route_bundle "mortgage-payment-calculator" "mortgage-calculator"
+fetch_route_bundle "calorie-deficit-calculator" "calorie-calculator"
+fetch_route_bundle "sales-tax-calculator" "sales-tax-calculator"
+write_htaccess
+write_hub
+write_sitemap
+write_observatory_snapshot
+verify_output
+
+echo "BOS-121 canonical overlay applied to ${dist_root}"


### PR DESCRIPTION
## Summary
This removes the manual-credential blocker on `BOS-795` by moving the BOS-121 rollout onto the existing protected GitHub deploy lane.

## What changed
- add `scripts/apply-bos-121-canonical-payload.sh` to overlay the approved BOS-121 utility routes into `dist/` after the normal site build
- update `.github/workflows/deploy.yml` to run that overlay during deploy
- expand deploy verification to require the BOS-121 contract on origin and public edge:
  - `/utility-sites/` returns `200`
  - `/mortgage-calculator/`, `/calorie-calculator/`, `/sales-tax-calculator/` return `200` with self-canonicals
  - legacy `/utility-sites/...` calculator routes return `301`
  - `observatory/utility-sites.latest.json` points at the short aliases
  - `sitemap.xml` includes the approved short aliases and excludes the legacy URLs
- remove `--delete` from the StackCP mirror step for now so this rollout does not prune unrelated live utility files while repo/live inventory is still out of parity

## Validation completed before PR
- ran `bash /home/ken/bosonit-site/scripts/apply-bos-121-canonical-payload.sh --dist-root /tmp/bos-121-canonical-overlay-dist`
- confirmed generated output contains:
  - BOS-121 redirect rules in `.htaccess`
  - `/utility-sites/` hub linking to the three approved aliases
  - self-canonical short-route HTML for mortgage, calorie, and sales tax
  - short-alias preview URLs in `observatory/utility-sites.latest.json`
  - sitemap entries for `/utility-sites/` and the three approved aliases

## Risk controls
- scope is limited to the BOS-121 route contract and the deploy lane needed to ship it
- the rollout uses the branch-protected `main` workflow instead of an ad hoc SSH session
- public verification stays in the workflow so a merge is not the same thing as unverifiable success

## Rollback
Revert this PR. That removes the BOS-121 overlay step and restores the prior deploy workflow behavior in one change set.

## Follow-up
After this ships, repo/live utility inventory should be reconciled so the StackCP mirror can safely return to destructive sync when appropriate.
