### PR TITLE
BOS-795: fix BOS-121 overlay runner compatibility

### DIFF
--- a/scripts/apply-bos-121-canonical-payload.sh
+++ b/scripts/apply-bos-121-canonical-payload.sh
@@ -41,7 +41,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for required in curl mkdir mktemp perl rg cp; do
+for required in curl mkdir mktemp perl grep cp; do
   if ! command -v "${required}" >/dev/null 2>&1; then
     echo "Missing required command: ${required}" >&2
     exit 1
@@ -377,22 +377,22 @@ fetch_route_bundle() {
 }
 
 verify_output() {
-  rg -Fq 'href="/mortgage-calculator/"' "${dist_root}/utility-sites/index.html"
-  rg -Fq 'href="/calorie-calculator/"' "${dist_root}/utility-sites/index.html"
-  rg -Fq 'href="/sales-tax-calculator/"' "${dist_root}/utility-sites/index.html"
-  rg -Fq 'rel="canonical" href="https://www.bosonit.org/mortgage-calculator/"' "${dist_root}/mortgage-calculator/index.html"
-  rg -Fq 'rel="canonical" href="https://www.bosonit.org/calorie-calculator/"' "${dist_root}/calorie-calculator/index.html"
-  rg -Fq 'rel="canonical" href="https://www.bosonit.org/sales-tax-calculator/"' "${dist_root}/sales-tax-calculator/index.html"
-  rg -Fq 'RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]' "${dist_root}/.htaccess"
-  rg -Fq 'RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]' "${dist_root}/.htaccess"
-  rg -Fq 'RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]' "${dist_root}/.htaccess"
-  rg -Fq '"preview_url": "/mortgage-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
-  rg -Fq '"preview_url": "/calorie-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
-  rg -Fq '"preview_url": "/sales-tax-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
-  rg -Fq 'https://www.bosonit.org/utility-sites/' "${dist_root}/sitemap.xml"
-  rg -Fq 'https://www.bosonit.org/mortgage-calculator/' "${dist_root}/sitemap.xml"
-  rg -Fq 'https://www.bosonit.org/calorie-calculator/' "${dist_root}/sitemap.xml"
-  rg -Fq 'https://www.bosonit.org/sales-tax-calculator/' "${dist_root}/sitemap.xml"
+  grep -Fq 'href="/mortgage-calculator/"' "${dist_root}/utility-sites/index.html"
+  grep -Fq 'href="/calorie-calculator/"' "${dist_root}/utility-sites/index.html"
+  grep -Fq 'href="/sales-tax-calculator/"' "${dist_root}/utility-sites/index.html"
+  grep -Fq 'rel="canonical" href="https://www.bosonit.org/mortgage-calculator/"' "${dist_root}/mortgage-calculator/index.html"
+  grep -Fq 'rel="canonical" href="https://www.bosonit.org/calorie-calculator/"' "${dist_root}/calorie-calculator/index.html"
+  grep -Fq 'rel="canonical" href="https://www.bosonit.org/sales-tax-calculator/"' "${dist_root}/sales-tax-calculator/index.html"
+  grep -Fq 'RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]' "${dist_root}/.htaccess"
+  grep -Fq 'RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]' "${dist_root}/.htaccess"
+  grep -Fq 'RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]' "${dist_root}/.htaccess"
+  grep -Fq '"preview_url": "/mortgage-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
+  grep -Fq '"preview_url": "/calorie-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
+  grep -Fq '"preview_url": "/sales-tax-calculator/"' "${dist_root}/observatory/utility-sites.latest.json"
+  grep -Fq 'https://www.bosonit.org/utility-sites/' "${dist_root}/sitemap.xml"
+  grep -Fq 'https://www.bosonit.org/mortgage-calculator/' "${dist_root}/sitemap.xml"
+  grep -Fq 'https://www.bosonit.org/calorie-calculator/' "${dist_root}/sitemap.xml"
+  grep -Fq 'https://www.bosonit.org/sales-tax-calculator/' "${dist_root}/sitemap.xml"
 }
 
 fetch_route_bundle "mortgage-payment-calculator" "mortgage-calculator"


### PR DESCRIPTION
## Summary
Follow-up to PR `#38` after the post-merge `Deploy Site` push run failed in the BOS-121 overlay step.

## Failure addressed
- merged commit: `2a4722b9b08ea4922859d997d3e388484e7658bf`
- failed workflow run: `Deploy Site` https://github.com/BosonIT-org/bosonit-site/actions/runs/25618886032
- failing step: `Run bash ./scripts/apply-bos-121-canonical-payload.sh`

## What changed
- replace the overlay script's `rg` dependency with `grep`, which is guaranteed on the GitHub runner
- keep the overlay logic and the BOS-121 route contract unchanged

## Validation completed before PR
- ran `bash /home/ken/bosonit-site/scripts/apply-bos-121-canonical-payload.sh --dist-root /tmp/bos-121-canonical-overlay-dist-r2`
- confirmed the regenerated short-route canonical, hub link, and observatory preview receipts still match BOS-121

## Risk controls
- script-only fix; no workflow file changes
- no rollout-scope expansion relative to PR `#38`

## Rollback
Revert this PR to restore the merged script from PR `#38`.
