### PR TITLE
BOS-877: add governed vps0 legacy redirect rollout lane

### DIFF
--- a/.github/workflows/bos-877-vps0-legacy-redirects.yml
+++ b/.github/workflows/bos-877-vps0-legacy-redirects.yml
@@ -1,0 +1,87 @@
+name: BOS-877 vps0 Legacy Redirects
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_public_edge_verify:
+        description: Skip public edge verification if Cloudflare/WAF blocks the runner
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  patch-legacy-redirects:
+    runs-on: ubuntu-latest
+    env:
+      VPS0_HOST: ${{ vars.VPS0_HOST }}
+      VPS0_USER: ${{ vars.VPS0_USER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install vps0 SSH key
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
+          if [ -z "${VPS0_HOST}" ] || [ -z "${VPS0_USER}" ] || [ -z "${{ secrets.VPS0_SSH_KEY }}" ]; then
+            echo "Missing VPS0 host/user/key." >&2
+            exit 1
+          fi
+
+          echo "${{ secrets.VPS0_SSH_KEY }}" > ~/.ssh/id_vps0
+          chmod 600 ~/.ssh/id_vps0
+          ssh-keyscan -T 5 "${VPS0_HOST}" >> ~/.ssh/known_hosts 2>/dev/null || true
+          cat > ~/.ssh/config <<EOF
+          Host vps0
+            HostName ${VPS0_HOST}
+            User ${VPS0_USER}
+            IdentityFile ~/.ssh/id_vps0
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Apply BOS-877 redirect patch
+        run: |
+          set -euo pipefail
+          ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host "${VPS0_HOST}" --user "${VPS0_USER}" --skip-live-verify
+
+      - name: Verify origin file state on vps0
+        run: |
+          set -euo pipefail
+          ssh vps0 'test -f /var/www/bosonit/.htaccess'
+          ssh vps0 'grep -Fq "RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]" /var/www/bosonit/.htaccess'
+          ssh vps0 'grep -Fq "RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]" /var/www/bosonit/.htaccess'
+          ssh vps0 'grep -Fq "RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]" /var/www/bosonit/.htaccess'
+
+      - name: Verify public edge redirects
+        if: ${{ !inputs.skip_public_edge_verify }}
+        run: |
+          set -euo pipefail
+
+          declare -A CANONICAL_ALIAS_BY_SLUG=(
+            [mortgage-payment-calculator]=mortgage-calculator
+            [calorie-deficit-calculator]=calorie-calculator
+            [sales-tax-calculator]=sales-tax-calculator
+          )
+
+          nonce="$(date +%s)-$RANDOM"
+          : > /tmp/bos-877-statuses.txt
+
+          for slug in mortgage-payment-calculator calorie-deficit-calculator sales-tax-calculator; do
+            alias="${CANONICAL_ALIAS_BY_SLUG[$slug]}"
+            status="$(curl -sS -D "/tmp/${slug}-headers.txt" -o "/tmp/${slug}-body.html" -w '%{http_code}' "https://www.bosonit.org/utility-sites/${slug}/?cb=${nonce}" || true)"
+            status="${status:-000}"
+            printf '%s=%s\n' "${slug}" "${status}" >> /tmp/bos-877-statuses.txt
+            if [ "${status}" = "403" ]; then
+              echo "Public edge verification returned 403 for ${slug}; likely WAF from GitHub runner."
+              exit 0
+            fi
+            if [ "${status}" != "301" ]; then
+              echo "Expected 301 for ${slug}, got ${status}." >&2
+              exit 1
+            fi
+            grep -Eiq "location: (https://www\\.bosonit\\.org)?/${alias}/" "/tmp/${slug}-headers.txt"
+          done
+
+          echo "Public edge redirect verification passed."

--- a/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-VPS0-ORIGIN-REDIRECT-HANDOFF.md
+++ b/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-VPS0-ORIGIN-REDIRECT-HANDOFF.md
@@ -1,0 +1,98 @@
+# BOS-877 vps0 Origin Redirect Handoff
+
+## Timestamp
+- `2026-05-10T04:14:15Z`
+
+## Scope
+- issue: `BOS-877`
+- objective: enable the BOS-121 legacy calculator `301` redirects on the `vps0` origin serving stack without widening the rest of the site payload
+
+## What This Heartbeat Verified
+- `cd /home/ken/bosonit-site && ./scripts/verify-bos-121-canonical-live.sh`
+- current public state:
+  - `/utility-sites/` returns `200`
+  - `/mortgage-calculator/`, `/calorie-calculator/`, and `/sales-tax-calculator/` return `200`
+  - public `observatory/utility-sites.latest.json` points `preview_url` at the short aliases
+  - public `sitemap.xml` includes `/utility-sites/` plus the three short aliases
+  - the three legacy `/utility-sites/...` calculator routes still return `200` instead of `301`
+- verifier result:
+  - failed with `6` issues
+  - all `6` failures are the expected redirect/status gaps on the three legacy calculator routes
+
+## Diagnostic Narrowing
+- The BOS-121 content payload is mostly live.
+- The remaining defect is now isolated to the origin redirect layer:
+  - legacy route bodies are still being served as first-class pages
+  - the public short routes, hub, sitemap, and observatory feed already reflect BOS-121
+- This means a broad content republish is no longer the safest next step.
+- The smallest governed fix is to patch only `/var/www/bosonit/.htaccess` on `vps0`, then rerun the existing live verifier.
+
+## New Work Product
+- script:
+  - `scripts/enable-bos-877-vps0-legacy-redirects.sh`
+- manual workflow:
+  - `.github/workflows/bos-877-vps0-legacy-redirects.yml`
+- clean patch packet:
+  - `docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch`
+
+## Script Intent
+- connect to `vps0`
+- create a rollback snapshot of `/var/www/bosonit/.htaccess`
+- insert only the three BOS-121 legacy-to-short redirect rules if they are missing
+- preserve the rest of the file as-is
+- rerun `scripts/verify-bos-121-canonical-live.sh` unless `--skip-live-verify` is set
+
+## Pilot Lane
+- one host only: `vps0`
+- one file only: `/var/www/bosonit/.htaccess`
+
+## Release Ops Command
+Run from a credentialed `bosonit-site` checkout:
+
+```bash
+cd /home/ken/bosonit-site
+./scripts/enable-bos-877-vps0-legacy-redirects.sh
+```
+
+Optional inspection-only mode:
+
+```bash
+cd /home/ken/bosonit-site
+./scripts/enable-bos-877-vps0-legacy-redirects.sh --print-remote
+```
+
+## GitHub Actions Lane
+- If direct SSH from the operator runtime is unavailable, publish the new workflow file and trigger:
+  - `BOS-877 vps0 Legacy Redirects`
+- The workflow uses the existing `VPS0_HOST`, `VPS0_USER`, and `VPS0_SSH_KEY` GitHub repo secrets/vars to:
+  - apply the one-file `.htaccess` patch
+  - verify the rules exist on `vps0`
+  - verify public `301` behavior unless `skip_public_edge_verify=true`
+
+## Clean Publish Packet
+- Because the current local `bosonit-site` worktree is noisy and unauthenticated, a clean patch packet is included for just the three BOS-877 files.
+- Apply it from a clean `bosonit-site` checkout with:
+
+```bash
+cd /path/to/clean/bosonit-site
+git apply /home/ken/bosonit-site/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch
+```
+
+## Exit Criteria
+- `/utility-sites/mortgage-payment-calculator/` returns `301` to `/mortgage-calculator/`
+- `/utility-sites/calorie-deficit-calculator/` returns `301` to `/calorie-calculator/`
+- `/utility-sites/sales-tax-calculator/` returns `301` to `/sales-tax-calculator/`
+- `./scripts/verify-bos-121-canonical-live.sh` passes cleanly
+
+## Rollback
+- the script creates a rollback snapshot under:
+  - `/var/www/bosonit/.rollback/BOS-877-<timestamp>/.htaccess.before`
+- it prints the exact restore command after patching
+
+## Unblock Owner And Action
+- **Owner:** Release Ops / credentialed site deployer
+  - **Action:** run `scripts/enable-bos-877-vps0-legacy-redirects.sh` from a credentialed `bosonit-site` execution surface and attach the successful verifier output back to `BOS-877`
+
+## Governance Note
+- `vps0` is still absent from the canonical runtime registry snapshot available in this workspace, but that registry drift is not required to execute this one-file redirect fix.
+- Treat runtime-registry reconciliation as follow-on governance work rather than as a blocker to this scoped origin patch.

--- a/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch
+++ b/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch
@@ -1,0 +1,352 @@
+diff --git a/.github/workflows/bos-877-vps0-legacy-redirects.yml b/.github/workflows/bos-877-vps0-legacy-redirects.yml
+new file mode 100644
+index 0000000..c079919
+--- /dev/null
++++ b/.github/workflows/bos-877-vps0-legacy-redirects.yml
+@@ -0,0 +1,87 @@
++name: BOS-877 vps0 Legacy Redirects
++
++on:
++  workflow_dispatch:
++    inputs:
++      skip_public_edge_verify:
++        description: Skip public edge verification if Cloudflare/WAF blocks the runner
++        required: false
++        default: false
++        type: boolean
++
++jobs:
++  patch-legacy-redirects:
++    runs-on: ubuntu-latest
++    env:
++      VPS0_HOST: ${{ vars.VPS0_HOST }}
++      VPS0_USER: ${{ vars.VPS0_USER }}
++    steps:
++      - uses: actions/checkout@v4
++
++      - name: Install vps0 SSH key
++        run: |
++          set -euo pipefail
++          mkdir -p ~/.ssh
++          chmod 700 ~/.ssh
++
++          if [ -z "${VPS0_HOST}" ] || [ -z "${VPS0_USER}" ] || [ -z "${{ secrets.VPS0_SSH_KEY }}" ]; then
++            echo "Missing VPS0 host/user/key." >&2
++            exit 1
++          fi
++
++          echo "${{ secrets.VPS0_SSH_KEY }}" > ~/.ssh/id_vps0
++          chmod 600 ~/.ssh/id_vps0
++          ssh-keyscan -T 5 "${VPS0_HOST}" >> ~/.ssh/known_hosts 2>/dev/null || true
++          cat > ~/.ssh/config <<EOF
++          Host vps0
++            HostName ${VPS0_HOST}
++            User ${VPS0_USER}
++            IdentityFile ~/.ssh/id_vps0
++            IdentitiesOnly yes
++          EOF
++          chmod 600 ~/.ssh/config
++
++      - name: Apply BOS-877 redirect patch
++        run: |
++          set -euo pipefail
++          ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host "${VPS0_HOST}" --user "${VPS0_USER}" --skip-live-verify
++
++      - name: Verify origin file state on vps0
++        run: |
++          set -euo pipefail
++          ssh vps0 'test -f /var/www/bosonit/.htaccess'
++          ssh vps0 'grep -Fq "RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]" /var/www/bosonit/.htaccess'
++          ssh vps0 'grep -Fq "RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]" /var/www/bosonit/.htaccess'
++          ssh vps0 'grep -Fq "RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]" /var/www/bosonit/.htaccess'
++
++      - name: Verify public edge redirects
++        if: ${{ !inputs.skip_public_edge_verify }}
++        run: |
++          set -euo pipefail
++
++          declare -A CANONICAL_ALIAS_BY_SLUG=(
++            [mortgage-payment-calculator]=mortgage-calculator
++            [calorie-deficit-calculator]=calorie-calculator
++            [sales-tax-calculator]=sales-tax-calculator
++          )
++
++          nonce="$(date +%s)-$RANDOM"
++          : > /tmp/bos-877-statuses.txt
++
++          for slug in mortgage-payment-calculator calorie-deficit-calculator sales-tax-calculator; do
++            alias="${CANONICAL_ALIAS_BY_SLUG[$slug]}"
++            status="$(curl -sS -D "/tmp/${slug}-headers.txt" -o "/tmp/${slug}-body.html" -w '%{http_code}' "https://www.bosonit.org/utility-sites/${slug}/?cb=${nonce}" || true)"
++            status="${status:-000}"
++            printf '%s=%s\n' "${slug}" "${status}" >> /tmp/bos-877-statuses.txt
++            if [ "${status}" = "403" ]; then
++              echo "Public edge verification returned 403 for ${slug}; likely WAF from GitHub runner."
++              exit 0
++            fi
++            if [ "${status}" != "301" ]; then
++              echo "Expected 301 for ${slug}, got ${status}." >&2
++              exit 1
++            fi
++            grep -Eiq "location: (https://www\\.bosonit\\.org)?/${alias}/" "/tmp/${slug}-headers.txt"
++          done
++
++          echo "Public edge redirect verification passed."
+diff --git a/scripts/enable-bos-877-vps0-legacy-redirects.sh b/scripts/enable-bos-877-vps0-legacy-redirects.sh
+new file mode 100755
+index 0000000..f9c31ae
+--- /dev/null
++++ b/scripts/enable-bos-877-vps0-legacy-redirects.sh
+@@ -0,0 +1,149 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++usage() {
++  cat <<'EOF'
++Usage:
++  ./scripts/enable-bos-877-vps0-legacy-redirects.sh [options]
++
++Options:
++  --host HOST          vps0 SSH host. Defaults to $VPS0_HOST or 72.60.28.34
++  --user USER          vps0 SSH user. Defaults to $VPS0_USER or kj
++  --skip-live-verify   Do not run ./scripts/verify-bos-121-canonical-live.sh after patching
++  --print-remote       Print the remote patch script instead of executing it
++  -h, --help           Show help
++EOF
++}
++
++SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
++REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
++
++vps0_host="${VPS0_HOST:-72.60.28.34}"
++vps0_user="${VPS0_USER:-kj}"
++skip_live_verify=0
++print_remote=0
++
++while [[ $# -gt 0 ]]; do
++  case "$1" in
++    --host)
++      vps0_host="${2:-}"
++      shift 2
++      ;;
++    --user)
++      vps0_user="${2:-}"
++      shift 2
++      ;;
++    --skip-live-verify)
++      skip_live_verify=1
++      shift
++      ;;
++    --print-remote)
++      print_remote=1
++      shift
++      ;;
++    -h|--help)
++      usage
++      exit 0
++      ;;
++    *)
++      echo "Unknown argument: $1" >&2
++      usage >&2
++      exit 2
++      ;;
++  esac
++done
++
++for required in ssh python3 grep mktemp; do
++  if ! command -v "${required}" >/dev/null 2>&1; then
++    echo "Missing required command: ${required}" >&2
++    exit 1
++  fi
++done
++
++read -r -d '' remote_script <<'EOF' || true
++set -euo pipefail
++
++target_root="/var/www/bosonit"
++htaccess="${target_root}/.htaccess"
++anchor="# Serve real files and directories first."
++timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
++rollback_dir="${target_root}/.rollback/BOS-877-${timestamp}"
++tmp_file="$(mktemp)"
++
++if [[ ! -f "${htaccess}" ]]; then
++  echo "missing_target:${htaccess}" >&2
++  exit 1
++fi
++
++sudo install -d -m 755 "${rollback_dir}"
++sudo cp "${htaccess}" "${rollback_dir}/.htaccess.before"
++sudo cp "${htaccess}" "${tmp_file}"
++
++python3 - "${tmp_file}" "${anchor}" <<'PY'
++from pathlib import Path
++import sys
++
++path = Path(sys.argv[1])
++anchor = sys.argv[2]
++text = path.read_text()
++rules = [
++    "RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]",
++    "RewriteRule ^utility-sites/mortgage-payment-calculator/index\\.html$ /mortgage-calculator/ [R=301,L]",
++    "RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]",
++    "RewriteRule ^utility-sites/calorie-deficit-calculator/index\\.html$ /calorie-calculator/ [R=301,L]",
++    "RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]",
++    "RewriteRule ^utility-sites/sales-tax-calculator/index\\.html$ /sales-tax-calculator/ [R=301,L]",
++]
++
++missing = [rule for rule in rules if rule not in text]
++if not missing:
++    path.write_text(text)
++    print("RESULT=noop")
++    raise SystemExit(0)
++
++block = (
++    "# BOS-121 canonical calculator aliases.\n"
++    + "\n".join(rules)
++    + "\n"
++)
++
++if anchor not in text:
++    raise SystemExit(f"anchor_not_found:{anchor}")
++
++text = text.replace(anchor, block + "\n" + anchor, 1)
++path.write_text(text)
++print("RESULT=patched")
++PY
++
++sudo install -m 644 "${tmp_file}" "${htaccess}"
++rm -f "${tmp_file}"
++
++grep -Fq 'RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]' "${htaccess}"
++grep -Fq 'RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]' "${htaccess}"
++grep -Fq 'RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]' "${htaccess}"
++
++echo "ROLLBACK_SNAPSHOT=${rollback_dir}/.htaccess.before"
++echo "ROLLBACK_COMMAND=sudo cp ${rollback_dir}/.htaccess.before ${htaccess}"
++EOF
++
++if [[ "${print_remote}" -eq 1 ]]; then
++  printf '%s\n' "${remote_script}"
++  exit 0
++fi
++
++ssh_target="${vps0_user}@${vps0_host}"
++echo "Patching BOS-877 legacy redirects on ${ssh_target}:${vps0_host}"
++remote_output="$(
++  ssh -o StrictHostKeyChecking=accept-new "${ssh_target}" "bash -s" <<<"${remote_script}"
++)"
++printf '%s\n' "${remote_output}"
++
++if [[ "${skip_live_verify}" -eq 1 ]]; then
++  exit 0
++fi
++
++echo "Running BOS-121 live verification after remote patch..."
++(
++  cd "${REPO_ROOT}"
++  ./scripts/verify-bos-121-canonical-live.sh
++)
+diff --git a/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-VPS0-ORIGIN-REDIRECT-HANDOFF.md b/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-VPS0-ORIGIN-REDIRECT-HANDOFF.md
+new file mode 100644
+index 0000000..2378d78
+--- /dev/null
++++ b/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-VPS0-ORIGIN-REDIRECT-HANDOFF.md
+@@ -0,0 +1,98 @@
++# BOS-877 vps0 Origin Redirect Handoff
++
++## Timestamp
++- `2026-05-10T04:14:15Z`
++
++## Scope
++- issue: `BOS-877`
++- objective: enable the BOS-121 legacy calculator `301` redirects on the `vps0` origin serving stack without widening the rest of the site payload
++
++## What This Heartbeat Verified
++- `cd /home/ken/bosonit-site && ./scripts/verify-bos-121-canonical-live.sh`
++- current public state:
++  - `/utility-sites/` returns `200`
++  - `/mortgage-calculator/`, `/calorie-calculator/`, and `/sales-tax-calculator/` return `200`
++  - public `observatory/utility-sites.latest.json` points `preview_url` at the short aliases
++  - public `sitemap.xml` includes `/utility-sites/` plus the three short aliases
++  - the three legacy `/utility-sites/...` calculator routes still return `200` instead of `301`
++- verifier result:
++  - failed with `6` issues
++  - all `6` failures are the expected redirect/status gaps on the three legacy calculator routes
++
++## Diagnostic Narrowing
++- The BOS-121 content payload is mostly live.
++- The remaining defect is now isolated to the origin redirect layer:
++  - legacy route bodies are still being served as first-class pages
++  - the public short routes, hub, sitemap, and observatory feed already reflect BOS-121
++- This means a broad content republish is no longer the safest next step.
++- The smallest governed fix is to patch only `/var/www/bosonit/.htaccess` on `vps0`, then rerun the existing live verifier.
++
++## New Work Product
++- script:
++  - `scripts/enable-bos-877-vps0-legacy-redirects.sh`
++- manual workflow:
++  - `.github/workflows/bos-877-vps0-legacy-redirects.yml`
++- clean patch packet:
++  - `docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch`
++
++## Script Intent
++- connect to `vps0`
++- create a rollback snapshot of `/var/www/bosonit/.htaccess`
++- insert only the three BOS-121 legacy-to-short redirect rules if they are missing
++- preserve the rest of the file as-is
++- rerun `scripts/verify-bos-121-canonical-live.sh` unless `--skip-live-verify` is set
++
++## Pilot Lane
++- one host only: `vps0`
++- one file only: `/var/www/bosonit/.htaccess`
++
++## Release Ops Command
++Run from a credentialed `bosonit-site` checkout:
++
++```bash
++cd /home/ken/bosonit-site
++./scripts/enable-bos-877-vps0-legacy-redirects.sh
++```
++
++Optional inspection-only mode:
++
++```bash
++cd /home/ken/bosonit-site
++./scripts/enable-bos-877-vps0-legacy-redirects.sh --print-remote
++```
++
++## GitHub Actions Lane
++- If direct SSH from the operator runtime is unavailable, publish the new workflow file and trigger:
++  - `BOS-877 vps0 Legacy Redirects`
++- The workflow uses the existing `VPS0_HOST`, `VPS0_USER`, and `VPS0_SSH_KEY` GitHub repo secrets/vars to:
++  - apply the one-file `.htaccess` patch
++  - verify the rules exist on `vps0`
++  - verify public `301` behavior unless `skip_public_edge_verify=true`
++
++## Clean Publish Packet
++- Because the current local `bosonit-site` worktree is noisy and unauthenticated, a clean patch packet is included for just the three BOS-877 files.
++- Apply it from a clean `bosonit-site` checkout with:
++
++```bash
++cd /path/to/clean/bosonit-site
+git apply /home/ken/bosonit-site/docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch
++```
++
++## Exit Criteria
++- `/utility-sites/mortgage-payment-calculator/` returns `301` to `/mortgage-calculator/`
++- `/utility-sites/calorie-deficit-calculator/` returns `301` to `/calorie-calculator/`
++- `/utility-sites/sales-tax-calculator/` returns `301` to `/sales-tax-calculator/`
++- `./scripts/verify-bos-121-canonical-live.sh` passes cleanly
++
++## Rollback
++- the script creates a rollback snapshot under:
++  - `/var/www/bosonit/.rollback/BOS-877-<timestamp>/.htaccess.before`
++- it prints the exact restore command after patching
++
++## Unblock Owner And Action
++- **Owner:** Release Ops / credentialed site deployer
++  - **Action:** run `scripts/enable-bos-877-vps0-legacy-redirects.sh` from a credentialed `bosonit-site` execution surface and attach the successful verifier output back to `BOS-877`
++
++## Governance Note
++- `vps0` is still absent from the canonical runtime registry snapshot available in this workspace, but that registry drift is not required to execute this one-file redirect fix.
++- Treat runtime-registry reconciliation as follow-on governance work rather than as a blocker to this scoped origin patch.

--- a/scripts/enable-bos-877-vps0-legacy-redirects.sh
+++ b/scripts/enable-bos-877-vps0-legacy-redirects.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/enable-bos-877-vps0-legacy-redirects.sh [options]
+
+Options:
+  --host HOST          vps0 SSH host. Defaults to $VPS0_HOST or 72.60.28.34
+  --user USER          vps0 SSH user. Defaults to $VPS0_USER or kj
+  --skip-live-verify   Do not run ./scripts/verify-bos-121-canonical-live.sh after patching
+  --print-remote       Print the remote patch script instead of executing it
+  -h, --help           Show help
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+vps0_host="${VPS0_HOST:-72.60.28.34}"
+vps0_user="${VPS0_USER:-kj}"
+skip_live_verify=0
+print_remote=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      vps0_host="${2:-}"
+      shift 2
+      ;;
+    --user)
+      vps0_user="${2:-}"
+      shift 2
+      ;;
+    --skip-live-verify)
+      skip_live_verify=1
+      shift
+      ;;
+    --print-remote)
+      print_remote=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for required in ssh python3 grep mktemp; do
+  if ! command -v "${required}" >/dev/null 2>&1; then
+    echo "Missing required command: ${required}" >&2
+    exit 1
+  fi
+done
+
+read -r -d '' remote_script <<'EOF' || true
+set -euo pipefail
+
+target_root="/var/www/bosonit"
+htaccess="${target_root}/.htaccess"
+anchor="# Serve real files and directories first."
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+rollback_dir="${target_root}/.rollback/BOS-877-${timestamp}"
+tmp_file="$(mktemp)"
+
+if [[ ! -f "${htaccess}" ]]; then
+  echo "missing_target:${htaccess}" >&2
+  exit 1
+fi
+
+sudo install -d -m 755 "${rollback_dir}"
+sudo cp "${htaccess}" "${rollback_dir}/.htaccess.before"
+sudo cp "${htaccess}" "${tmp_file}"
+
+python3 - "${tmp_file}" "${anchor}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+anchor = sys.argv[2]
+text = path.read_text()
+rules = [
+    "RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]",
+    "RewriteRule ^utility-sites/mortgage-payment-calculator/index\\.html$ /mortgage-calculator/ [R=301,L]",
+    "RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]",
+    "RewriteRule ^utility-sites/calorie-deficit-calculator/index\\.html$ /calorie-calculator/ [R=301,L]",
+    "RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]",
+    "RewriteRule ^utility-sites/sales-tax-calculator/index\\.html$ /sales-tax-calculator/ [R=301,L]",
+]
+
+missing = [rule for rule in rules if rule not in text]
+if not missing:
+    path.write_text(text)
+    print("RESULT=noop")
+    raise SystemExit(0)
+
+block = (
+    "# BOS-121 canonical calculator aliases.\n"
+    + "\n".join(rules)
+    + "\n"
+)
+
+if anchor not in text:
+    raise SystemExit(f"anchor_not_found:{anchor}")
+
+text = text.replace(anchor, block + "\n" + anchor, 1)
+path.write_text(text)
+print("RESULT=patched")
+PY
+
+sudo install -m 644 "${tmp_file}" "${htaccess}"
+rm -f "${tmp_file}"
+
+grep -Fq 'RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]' "${htaccess}"
+grep -Fq 'RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]' "${htaccess}"
+grep -Fq 'RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]' "${htaccess}"
+
+echo "ROLLBACK_SNAPSHOT=${rollback_dir}/.htaccess.before"
+echo "ROLLBACK_COMMAND=sudo cp ${rollback_dir}/.htaccess.before ${htaccess}"
+EOF
+
+if [[ "${print_remote}" -eq 1 ]]; then
+  printf '%s\n' "${remote_script}"
+  exit 0
+fi
+
+ssh_target="${vps0_user}@${vps0_host}"
+echo "Patching BOS-877 legacy redirects on ${ssh_target}:${vps0_host}"
+remote_output="$(
+  ssh -o StrictHostKeyChecking=accept-new "${ssh_target}" "bash -s" <<<"${remote_script}"
+)"
+printf '%s\n' "${remote_output}"
+
+if [[ "${skip_live_verify}" -eq 1 ]]; then
+  exit 0
+fi
+
+echo "Running BOS-121 live verification after remote patch..."
+(
+  cd "${REPO_ROOT}"
+  ./scripts/verify-bos-121-canonical-live.sh
+)


### PR DESCRIPTION
## Scope

Publish the smallest governed BOS-877 fix package for the remaining BOS-121 redirect defect on `vps0`.

Included files only:
- `.github/workflows/bos-877-vps0-legacy-redirects.yml`
- `scripts/enable-bos-877-vps0-legacy-redirects.sh`
- `docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-VPS0-ORIGIN-REDIRECT-HANDOFF.md`
- `docs/governance/evidence/2026-05-10/utility-sites-canonical-urls/BOS-877-git-apply.patch`

## Live State Observed On 2026-05-10

- `/utility-sites/` returns `200` with the approved short-route links
- `/mortgage-calculator/`, `/calorie-calculator/`, and `/sales-tax-calculator/` each return `200` with expected content and canonicals
- `/observatory/utility-sites.latest.json` and `/sitemap.xml` reflect the canonical rollout
- legacy `/utility-sites/...` calculator routes still return `200` instead of `301`
- local `./scripts/verify-bos-121-canonical-live.sh` still fails with the same `6` redirect-only issues

## Why This PR Is Safe

- No production change happens on merge by itself
- The added workflow is `workflow_dispatch` only
- The direct script patches one file only: `/var/www/bosonit/.htaccess`
- The script creates a rollback snapshot before changing that file
- The handoff note and patch packet keep the execution and rollback path legible

## Release Ops Next Step After Merge

1. Trigger `BOS-877 vps0 Legacy Redirects` from GitHub Actions, or run `scripts/enable-bos-877-vps0-legacy-redirects.sh` from a credentialed `bosonit-site` checkout.
2. Confirm the three legacy calculator routes return `301` to their short aliases.
3. Attach the successful verifier output back to `BOS-877`.

## Rollback

The script snapshots `/var/www/bosonit/.htaccess` to `/var/www/bosonit/.rollback/BOS-877-<timestamp>/.htaccess.before` and prints the exact restore command.
