### PR TITLE
BOS-877: invoke redirect rollout script through bash

### DIFF
--- a/.github/workflows/bos-877-vps0-legacy-redirects.yml
+++ b/.github/workflows/bos-877-vps0-legacy-redirects.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Apply BOS-877 redirect patch
         run: |
           set -euo pipefail
-          ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host "${VPS0_HOST}" --user "${VPS0_USER}" --skip-live-verify
+          bash ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host "${VPS0_HOST}" --user "${VPS0_USER}" --skip-live-verify
 
       - name: Verify origin file state on vps0
         run: |


### PR DESCRIPTION
## Summary
- invoke the BOS-877 rollout script through bash in the workflow dispatch path
- keep the vps0 redirect lane otherwise unchanged

## Verification
- bash -n scripts/enable-bos-877-vps0-legacy-redirects.sh
- git diff --check

Fixes the failed dispatch mechanism for #44.