### PR TITLE
BOS-877: invoke vps0 redirect script through bash in workflow lane

### DIFF
--- a/.github/workflows/bos-877-vps0-legacy-redirects.yml
+++ b/.github/workflows/bos-877-vps0-legacy-redirects.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Apply BOS-877 redirect patch
         run: |
           set -euo pipefail
-          ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host "${VPS0_HOST}" --user "${VPS0_USER}" --skip-live-verify
+          bash ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host "${VPS0_HOST}" --user "${VPS0_USER}" --skip-live-verify
 
       - name: Verify origin file state on vps0
         run: |


### PR DESCRIPTION
## Scope

Repair the merged BOS-877 manual workflow lane so GitHub runners invoke the vps0 patch script through `bash` instead of relying on executable file mode.

Changed file only:
- `.github/workflows/bos-877-vps0-legacy-redirects.yml`

## Why This Is Needed

Workflow run `25620067799` failed before touching `vps0`.

Observed failure:
- job `patch-legacy-redirects`
- step `Apply BOS-877 redirect patch`
- exit `126`
- `Permission denied` on `./scripts/enable-bos-877-vps0-legacy-redirects.sh`

The runner already executes step bodies in Bash, but direct `./script` invocation still requires the executable bit. Calling the script as `bash ./scripts/enable-bos-877-vps0-legacy-redirects.sh ...` removes that dependency without widening the rollout surface.

## Risk

- no production change on merge by itself
- workflow remains `workflow_dispatch` only
- change is a one-line invocation fix in the existing BOS-877 lane
- release path and rollback behavior are unchanged

## Next Step After Merge

Re-run `BOS-877 vps0 Legacy Redirects` and verify the three legacy calculator routes return `301` to their short aliases.
