### PR TITLE
BOS-877: match SSH config to explicit vps0 host in workflow lane

### DIFF
--- a/.github/workflows/bos-877-vps0-legacy-redirects.yml
+++ b/.github/workflows/bos-877-vps0-legacy-redirects.yml
@@ -33,7 +33,7 @@ jobs:
           chmod 600 ~/.ssh/id_vps0
           ssh-keyscan -T 5 "${VPS0_HOST}" >> ~/.ssh/known_hosts 2>/dev/null || true
           cat > ~/.ssh/config <<EOF
-          Host vps0
+          Host vps0 ${VPS0_HOST}
             HostName ${VPS0_HOST}
             User ${VPS0_USER}
             IdentityFile ~/.ssh/id_vps0


### PR DESCRIPTION
## Scope

Repair the BOS-877 manual workflow lane so the installed SSH identity applies when the script connects to the explicit `user@host` target.

Changed file only:
- `.github/workflows/bos-877-vps0-legacy-redirects.yml`

## Why This Is Needed

After the prior `bash` invocation fix merged, rerun `25620167339` still failed before patching `vps0`.

Observed failure:
- job `patch-legacy-redirects`
- step `Apply BOS-877 redirect patch`
- exit `255`
- `Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password)`

Root cause:
- the workflow installed `~/.ssh/config` only for `Host vps0`
- the script is invoked with `--host` and `--user`, so it connects to `kj@72.60.28.34`
- that explicit target bypassed the alias-only SSH config and therefore missed `IdentityFile ~/.ssh/id_vps0`

This PR changes the SSH config host pattern from `Host vps0` to `Host vps0 ${VPS0_HOST}`, which makes the same identity apply to both `ssh vps0` and `ssh kj@72.60.28.34`.

## Risk

- no production change on merge by itself
- workflow remains `workflow_dispatch` only
- change is a one-line SSH config repair in the existing BOS-877 lane
- operator script, rollback behavior, and live verification scope are unchanged

## Next Step After Merge

Re-run `BOS-877 vps0 Legacy Redirects` and verify the three legacy calculator routes return `301` to their short aliases.
