### PR TITLE
BOS-877: target active nginx origin redirects

### DIFF
--- a/scripts/enable-bos-877-vps0-legacy-redirects.sh
+++ b/scripts/enable-bos-877-vps0-legacy-redirects.sh
@@ -9,7 +9,7 @@ Usage:
 Options:
   --host HOST          vps0 SSH host. Defaults to $VPS0_HOST or 72.60.28.34
   --user USER          vps0 SSH user. Defaults to $VPS0_USER or kj
-  --skip-live-verify   Do not run ./scripts/verify-bos-121-canonical-live.sh after patching
+  --skip-live-verify   Do not run BOS-121 public redirect verification after patching
   --print-remote       Print the remote patch script instead of executing it
   -h, --help           Show help
 EOF
@@ -63,67 +63,84 @@ done
 read -r -d '' remote_script <<'EOF' || true
 set -euo pipefail
 
-target_root="/var/www/bosonit"
-htaccess="${target_root}/.htaccess"
-anchor="# Serve real files and directories first."
+origin_conf="/opt/bmos-infra/nginx/default.conf"
+site_container="bmos-site-prod-1"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-rollback_dir="${target_root}/.rollback/BOS-877-${timestamp}"
+rollback_dir="$(dirname "${origin_conf}")/.rollback/BOS-877-${timestamp}"
 tmp_file="$(mktemp)"
 
-if [[ ! -f "${htaccess}" ]]; then
-  echo "missing_target:${htaccess}" >&2
+if [[ ! -f "${origin_conf}" ]]; then
+  echo "missing_target:${origin_conf}" >&2
   exit 1
 fi
 
-sudo install -d -m 755 "${rollback_dir}"
-sudo cp "${htaccess}" "${rollback_dir}/.htaccess.before"
-sudo cp "${htaccess}" "${tmp_file}"
+for required in docker python3 stat; do
+  if ! command -v "${required}" >/dev/null 2>&1; then
+    echo "missing_remote_command:${required}" >&2
+    exit 1
+  fi
+done
 
-python3 - "${tmp_file}" "${anchor}" <<'PY'
+owner="$(stat -c %U "${origin_conf}")"
+group="$(stat -c %G "${origin_conf}")"
+
+sudo -n install -d -m 755 "${rollback_dir}"
+sudo -n cp "${origin_conf}" "${rollback_dir}/default.conf.before"
+sudo -n cp "${origin_conf}" "${tmp_file}"
+sudo -n chown "$(id -un):$(id -gn)" "${tmp_file}"
+
+python3 - "${tmp_file}" <<'PY'
 from pathlib import Path
 import sys
 
 path = Path(sys.argv[1])
-anchor = sys.argv[2]
 text = path.read_text()
-rules = [
-    "RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]",
-    "RewriteRule ^utility-sites/mortgage-payment-calculator/index\\.html$ /mortgage-calculator/ [R=301,L]",
-    "RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]",
-    "RewriteRule ^utility-sites/calorie-deficit-calculator/index\\.html$ /calorie-calculator/ [R=301,L]",
-    "RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]",
-    "RewriteRule ^utility-sites/sales-tax-calculator/index\\.html$ /sales-tax-calculator/ [R=301,L]",
-]
+original = text
+start = "  # BOS-121 canonical calculator aliases.\n"
+end = "  # End BOS-121 canonical calculator aliases.\n"
+rules = {
+    "mortgage-payment-calculator": "mortgage-calculator",
+    "calorie-deficit-calculator": "calorie-calculator",
+    "sales-tax-calculator": "sales-tax-calculator",
+}
 
-missing = [rule for rule in rules if rule not in text]
-if not missing:
-    path.write_text(text)
-    print("RESULT=noop")
-    raise SystemExit(0)
+lines = [start.rstrip("\n")]
+for legacy, canonical in rules.items():
+    for suffix in ("", "/", "/index.html"):
+        lines.extend([
+            f"  location = /utility-sites/{legacy}{suffix} {{",
+            f"    return 301 /{canonical}/;",
+            "  }",
+        ])
+lines.append(end.rstrip("\n"))
+block = "\n".join(lines) + "\n"
 
-block = (
-    "# BOS-121 canonical calculator aliases.\n"
-    + "\n".join(rules)
-    + "\n"
-)
+if start in text and end in text:
+    before, rest = text.split(start, 1)
+    _, after = rest.split(end, 1)
+    text = before + block + after
+else:
+    anchor = "  location ~* \\.(?:css|js|mjs|json|png|jpe?g|gif|svg|webp|ico|woff2?|ttf)$ {\n"
+    if anchor not in text:
+        raise SystemExit(f"anchor_not_found:{anchor.strip()}")
+    text = text.replace(anchor, block + anchor, 1)
 
-if anchor not in text:
-    raise SystemExit(f"anchor_not_found:{anchor}")
-
-text = text.replace(anchor, block + "\n" + anchor, 1)
 path.write_text(text)
-print("RESULT=patched")
+print("RESULT=noop" if text == original else "RESULT=patched")
 PY
 
-sudo install -m 644 "${tmp_file}" "${htaccess}"
+sudo -n install -o "${owner}" -g "${group}" -m 644 "${tmp_file}" "${origin_conf}"
 rm -f "${tmp_file}"
 
-grep -Fq 'RewriteRule ^utility-sites/mortgage-payment-calculator/?$ /mortgage-calculator/ [R=301,L]' "${htaccess}"
-grep -Fq 'RewriteRule ^utility-sites/calorie-deficit-calculator/?$ /calorie-calculator/ [R=301,L]' "${htaccess}"
-grep -Fq 'RewriteRule ^utility-sites/sales-tax-calculator/?$ /sales-tax-calculator/ [R=301,L]' "${htaccess}"
+sudo -n docker exec "${site_container}" nginx -t
+sudo -n docker exec "${site_container}" nginx -s reload
 
-echo "ROLLBACK_SNAPSHOT=${rollback_dir}/.htaccess.before"
-echo "ROLLBACK_COMMAND=sudo cp ${rollback_dir}/.htaccess.before ${htaccess}"
+grep -Fq 'location = /utility-sites/mortgage-payment-calculator/' "${origin_conf}"
+grep -Fq 'location = /utility-sites/calorie-deficit-calculator/' "${origin_conf}"
+grep -Fq 'location = /utility-sites/sales-tax-calculator/' "${origin_conf}"
+
+echo "ROLLBACK_SNAPSHOT=${rollback_dir}/default.conf.before"
+echo "ROLLBACK_COMMAND=sudo cp ${rollback_dir}/default.conf.before ${origin_conf} && sudo docker exec ${site_container} nginx -t && sudo docker exec ${site_container} nginx -s reload"
 EOF
 
 if [[ "${print_remote}" -eq 1 ]]; then
@@ -134,7 +151,7 @@ fi
 ssh_target="${vps0_user}@${vps0_host}"
 echo "Patching BOS-877 legacy redirects on ${ssh_target}:${vps0_host}"
 remote_output="$(
-  ssh -o StrictHostKeyChecking=accept-new "${ssh_target}" "bash -s" <<<"${remote_script}"
+  ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new "${ssh_target}" "bash -s" <<<"${remote_script}"
 )"
 printf '%s\n' "${remote_output}"
 
@@ -143,7 +160,72 @@ if [[ "${skip_live_verify}" -eq 1 ]]; then
 fi
 
 echo "Running BOS-121 live verification after remote patch..."
-(
-  cd "${REPO_ROOT}"
-  ./scripts/verify-bos-121-canonical-live.sh
-)
+if [[ -x "${REPO_ROOT}/scripts/verify-bos-121-canonical-live.sh" ]]; then
+  (
+    cd "${REPO_ROOT}"
+    ./scripts/verify-bos-121-canonical-live.sh
+  )
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Missing required command for live verification: curl" >&2
+  exit 1
+fi
+
+nonce="$(date +%s)-$RANDOM"
+for legacy in mortgage-payment-calculator calorie-deficit-calculator sales-tax-calculator; do
+  case "${legacy}" in
+    mortgage-payment-calculator)
+      canonical="mortgage-calculator"
+      ;;
+    calorie-deficit-calculator)
+      canonical="calorie-calculator"
+      ;;
+    sales-tax-calculator)
+      canonical="sales-tax-calculator"
+      ;;
+    *)
+      echo "Unknown legacy calculator slug: ${legacy}" >&2
+      exit 1
+      ;;
+  esac
+  for suffix in "" "/" "/index.html"; do
+    headers="$(mktemp)"
+    body="$(mktemp)"
+    url="https://www.bosonit.org/utility-sites/${legacy}${suffix}?verify=${nonce}"
+    status="$(curl -sS -D "${headers}" -o "${body}" -w '%{http_code}' "${url}" || true)"
+    rm -f "${body}"
+    if [[ "${status}" != "301" ]]; then
+      cat "${headers}" >&2 || true
+      rm -f "${headers}"
+      echo "Expected 301 for ${url}, got ${status:-000}." >&2
+      exit 1
+    fi
+    if ! grep -Eiq "location: (https://www\\.bosonit\\.org)?/${canonical}/" "${headers}"; then
+      cat "${headers}" >&2 || true
+      rm -f "${headers}"
+      echo "Expected redirect location to /${canonical}/ for ${url}." >&2
+      exit 1
+    fi
+    rm -f "${headers}"
+  done
+done
+
+for canonical in mortgage-calculator calorie-calculator sales-tax-calculator; do
+  body="$(mktemp)"
+  status="$(curl -sS -o "${body}" -w '%{http_code}' "https://www.bosonit.org/${canonical}/?verify=${nonce}" || true)"
+  if [[ "${status}" != "200" ]]; then
+    rm -f "${body}"
+    echo "Expected 200 for /${canonical}/, got ${status:-000}." >&2
+    exit 1
+  fi
+  if ! grep -Fq "https://www.bosonit.org/${canonical}/" "${body}"; then
+    rm -f "${body}"
+    echo "Canonical body for /${canonical}/ does not include its self URL." >&2
+    exit 1
+  fi
+  rm -f "${body}"
+done
+
+echo "BOS-121 live verification passed."


### PR DESCRIPTION
## Summary
- update the BOS-877 rollout script to patch the active bmos-site-prod nginx config instead of inactive .htaccess rules
- preserve timestamped rollback evidence and validate/reload nginx in the site-prod container
- add a built-in public verification fallback for the BOS-121 canonical URL rollout

## Verification
- bash -n scripts/enable-bos-877-vps0-legacy-redirects.sh
- bash scripts/enable-bos-877-vps0-legacy-redirects.sh --print-remote | bash -n
- git diff --check
- bash ./scripts/enable-bos-877-vps0-legacy-redirects.sh --host 72.60.28.34 --user kj

Live verification passed after the production config was patched.